### PR TITLE
Add help message for no arguments

### DIFF
--- a/mkmorse.py
+++ b/mkmorse.py
@@ -210,6 +210,11 @@ if __name__ == '__main__':
     parser.add_argument('input', nargs='?', default=sys.stdin, type=argparse.FileType('r'),
                         help='Input text file (invalid chars ignored)')
 
+    if len(sys.argv)==1:
+        parser.print_help(sys.stderr)
+        sys.exit(1)
+
+
     args = parser.parse_args()
 
     if args.char_speed:


### PR DESCRIPTION
Current code shows the error "You must specify --output when using stdin" when run without arguments, adding this prints help.

Credit to https://stackoverflow.com/questions/4042452/display-help-message-with-python-argparse-when-script-is-called-without-any-argu